### PR TITLE
Fix : Deprecating Github API authentication through query parameters, should send the token in the header

### DIFF
--- a/wp-plugin-update-server/inc/class-wppus-update-server.php
+++ b/wp-plugin-update-server/inc/class-wppus-update-server.php
@@ -354,6 +354,9 @@ class WPPUS_Update_Server extends Wpup_UpdateServer {
 			'timeout'  => $timeout,
 			'stream'   => true,
 			'filename' => $local_filename,
+			'headers'  => array(
+				'Authorization' => 'token ' . $this->repository_credentials
+			)
 		) );
 
 		if ( is_wp_error( $response ) ) {

--- a/wp-plugin-update-server/inc/class-wppus-update-server.php
+++ b/wp-plugin-update-server/inc/class-wppus-update-server.php
@@ -354,6 +354,9 @@ class WPPUS_Update_Server extends Wpup_UpdateServer {
 			'timeout'  => $timeout,
 			'stream'   => true,
 			'filename' => $local_filename,
+			'headers' => array(
+                'Authorization' => 'token ' . $this->repository_credentials
+            )
 		) );
 
 		if ( is_wp_error( $response ) ) {

--- a/wp-plugin-update-server/lib/plugin-update-checker/Puc/v4p4/Vcs/GitHubApi.php
+++ b/wp-plugin-update-server/lib/plugin-update-checker/Puc/v4p4/Vcs/GitHubApi.php
@@ -332,10 +332,7 @@ if ( !class_exists('Puc_v4p4_Vcs_GitHubApi', false) ):
 		 * @return string
 		 */
 		public function signDownloadUrl($url) {
-			if ( empty($this->credentials) ) {
-				return $url;
-			}
-			return add_query_arg('access_token', $this->credentials, $url);
+			return $url;
 		}
 
 		/**


### PR DESCRIPTION
The Github API has changed its authentication policy in 2021. The access_token must now be in the header and not in the URL.  
See the blog post about this issue :
== > https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/

By accepting this pull request, the Github integration in the plugin will be functional again. 
I just don't guarantee in this commit that the entire evolution to the new Github API policy is handled, it just works fine !